### PR TITLE
6 reading is really slow when file size is more than 100 kb

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,8 +163,8 @@ const file1 = fs.open("Greeting.txt");
 const content = file1.content;
 
 console.log(content) // "Hello World"
-console.log(content.json) // null (because the content is not JSON parsable)
-console.log(content.ByteArray) // [ByteArray]
+console.log(content.json()) // null (because the content is not JSON parsable)
+console.log(content.ByteArray()) // [ByteArray]
 ```
 
 

--- a/src/File.js
+++ b/src/File.js
@@ -187,13 +187,19 @@ class File {
         content.__proto__.json = null;
         content.__proto__.ByteArray = null;
 
-        try {
-            content.__proto__.json = JSON.parse(content);
-        } catch { }
+        const Try = (callback) => {
+            return (...args) => {
+                try {
+                    return callback?.(...args)
+                } catch (e) {
+                    return null
+                }
+            }
+        }
 
-        try {
-            content.__proto__.ByteArray = Filic.StringToByteArray(content)
-        } catch { }
+        content.__proto__.json = Try(() => JSON.parse(content))
+
+        content.__proto__.ByteArray = Try(() => Filic.StringToByteArray(content))
 
         return content;
     }

--- a/src/Filic.js
+++ b/src/Filic.js
@@ -166,7 +166,7 @@ class Filic {
         let ByteArray = [];
         for (var i = 0; i < string.length; i++) {
             var code = string.charCodeAt(i);
-            ByteArray = ByteArray.concat([code]);
+            ByteArray.push(code);
         }
         return ByteArray;
     }


### PR DESCRIPTION
The performance hit issue was fixed when reading large files. It was because of String to `ByteArray` Conversion happening every single time you fetch the content of the file. So now user will have to call the function like `content.ByteArray()` in order to get the `ByteArray`