### PR TITLE
fix: using `rmdir` and `rmdirSync` instead of `rm` and `rmSync` for `Directory.deleteSelf` and `Directory.deleteSelfSync`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "filic",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filic",
-  "version": "2.2.2",
+  "version": "2.2.3",
   "description": "An Advance File System API",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/Directory.ts
+++ b/src/Directory.ts
@@ -29,11 +29,11 @@ class Directory extends Entity {
 
     // Delete Method
     public async deleteSelf(options?: DirectoryTypes.deleteSelfOptions): Promise<this> {
-        await fs.promises.rm(this.absolutePath, options)
+        await fs.promises.rmdir(this.absolutePath, options)
         return this;
     }
     public deleteSelfSync(options?: DirectoryTypes.deleteSelfSyncOptions): this {
-        fs.rmSync(this.absolutePath, options)
+        fs.rmdirSync(this.absolutePath, options)
         return this;
     }
 


### PR DESCRIPTION
#21