### PR TITLE
fix: Class static side 'typeof Directory' incorrectly extends base class static side 'typeof Entity'. Types of property 'create' are incompatible.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "filic",
-  "version": "3.5.1",
+  "version": "3.5.2",
   "description": "An Advance File System API",
   "types": "dist/index.d.ts",
   "main": "dist/index.js",

--- a/src/Directory.ts
+++ b/src/Directory.ts
@@ -359,7 +359,7 @@ class Directory extends Entity {
     }
 
     // create new instance
-    public static override create(options?: DirectoryOptions): Directory {
+    public static override create(options: DirectoryOptions): Directory {
         return new Directory(options);
     }
 


### PR DESCRIPTION
#38 